### PR TITLE
Fix broken templates; fix broken API serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,92 @@
-#ignore the config file
-all_stars.yaml
+# See also
+# https://github.com/github/gitignore/blob/master/Python.gitignore
+# https://github.com/django/django/blob/master/.gitignore
+# https://www.gitignore.io/api/django,python,intellij (bloated)
 
-#ignore virtual env directory 
-venv_as/
-
-#ds store
-/.DS_store
-.DS_store
-**/*.DS_Store
-**/*.DS_Store*
-**/**/*.DS_Store*
-
-#secret settings/keys, etc
-allstars/mysite/settings_secret.py
-allstars/mysite/secret.py
-
-#pycache folders
-**/**/*__pycache__/
+### Django ###
+*.log
+*.pot
+*.pyc
 __pycache__/
-**/*__pycache__/
+local_settings.py
+db.sqlite3
+media
 
-#migrations folders
-**/**/*migrations/
-**/*migrations/
+### Django secrets ###
+**/secrets.py
+
+### Intellij ###
+.idea/
+*.iml
+*.ipr
+*.iws
+*.uml
+out/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+venv/
+venv.bak/
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/

--- a/allstars/allstars/models.py
+++ b/allstars/allstars/models.py
@@ -9,122 +9,6 @@ from django.db import models
 from django.urls import reverse
 import datetime
 
-#=====================================================================
-# Auto-Generated Model Classes from Django
-#=====================================================================
-
-class AuthGroup(models.Model):
-    name = models.CharField(unique=True, max_length=80)
-
-    class Meta:
-        managed = False
-        db_table = 'auth_group'
-
-
-class AuthGroupPermissions(models.Model):
-    group = models.ForeignKey(AuthGroup, models.DO_NOTHING)
-    permission = models.ForeignKey('AuthPermission', models.DO_NOTHING)
-
-    class Meta:
-        managed = False
-        db_table = 'auth_group_permissions'
-        unique_together = (('group', 'permission'),)
-
-
-class AuthPermission(models.Model):
-    name = models.CharField(max_length=255)
-    content_type = models.ForeignKey('DjangoContentType', models.DO_NOTHING)
-    codename = models.CharField(max_length=100)
-
-    class Meta:
-        managed = False
-        db_table = 'auth_permission'
-        unique_together = (('content_type', 'codename'),)
-
-
-class AuthUser(models.Model):
-    password = models.CharField(max_length=128)
-    last_login = models.DateTimeField(blank=True, null=True)
-    is_superuser = models.IntegerField()
-    username = models.CharField(unique=True, max_length=150)
-    first_name = models.CharField(max_length=30)
-    last_name = models.CharField(max_length=150)
-    email = models.CharField(max_length=254)
-    is_staff = models.IntegerField()
-    is_active = models.IntegerField()
-    date_joined = models.DateTimeField()
-
-    class Meta:
-        managed = False
-        db_table = 'auth_user'
-
-
-class AuthUserGroups(models.Model):
-    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
-    group = models.ForeignKey(AuthGroup, models.DO_NOTHING)
-
-    class Meta:
-        managed = False
-        db_table = 'auth_user_groups'
-        unique_together = (('user', 'group'),)
-
-
-class AuthUserUserPermissions(models.Model):
-    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
-    permission = models.ForeignKey(AuthPermission, models.DO_NOTHING)
-
-    class Meta:
-        managed = False
-        db_table = 'auth_user_user_permissions'
-        unique_together = (('user', 'permission'),)
-
-
-class DjangoAdminLog(models.Model):
-    action_time = models.DateTimeField()
-    object_id = models.TextField(blank=True, null=True)
-    object_repr = models.CharField(max_length=200)
-    action_flag = models.PositiveSmallIntegerField()
-    change_message = models.TextField()
-    content_type = models.ForeignKey('DjangoContentType', models.DO_NOTHING, blank=True, null=True)
-    user = models.ForeignKey(AuthUser, models.DO_NOTHING)
-
-    class Meta:
-        managed = False
-        db_table = 'django_admin_log'
-
-
-class DjangoContentType(models.Model):
-    app_label = models.CharField(max_length=100)
-    model = models.CharField(max_length=100)
-
-    class Meta:
-        managed = False
-        db_table = 'django_content_type'
-        unique_together = (('app_label', 'model'),)
-
-
-class DjangoMigrations(models.Model):
-    app = models.CharField(max_length=255)
-    name = models.CharField(max_length=255)
-    applied = models.DateTimeField()
-
-    class Meta:
-        managed = False
-        db_table = 'django_migrations'
-
-
-class DjangoSession(models.Model):
-    session_key = models.CharField(primary_key=True, max_length=40)
-    session_data = models.TextField()
-    expire_date = models.DateTimeField()
-
-    class Meta:
-        managed = False
-        db_table = 'django_session'
-
-#============================================================================
-# Database Model Classes
-#============================================================================
 
 class AllStar(models.Model):
     all_star_id = models.AutoField(primary_key=True)
@@ -177,6 +61,7 @@ class League(models.Model):
     #def get_absolute_url(self):
         #return reverse('', args=[str(self.id)])
 
+
 class Team(models.Model):
     team_id = models.AutoField(primary_key=True)
     league = models.ForeignKey(League, on_delete=models.PROTECT)
@@ -225,6 +110,7 @@ class PersonRecord(models.Model):
     teams_as_player = models.ManyToManyField(
         Team,
         through='TeamAlign',
+        blank=True,
         related_name='player_on_team'
     )
 
@@ -232,7 +118,8 @@ class PersonRecord(models.Model):
     teams_as_coach = models.ManyToManyField(
         Team,
         through='Coach',
-        related_name='coach_on_team'
+        blank=True,
+        related_name='coach_on_team',
     )
 
     class Meta:
@@ -299,6 +186,7 @@ class TeamAlign(models.Model):
 
     #def get_absolute_url(self):
         #return reverse('', args=[str(self.id)])
+
 
 class Coach(models.Model):
     coach_id = models.AutoField(primary_key=True)

--- a/allstars/allstars/templates/allstars/allstarslist.html
+++ b/allstars/allstars/templates/allstars/allstarslist.html
@@ -14,7 +14,7 @@
 
   <p> Select an All-Star player to get a list of years they were active All-Stars. Each year will provide a breakdown of their All-Star game stats.</p>
 
-  {% include '/Users/beefbeverly/Documents/GitHub/SI664-Final-Project-Mens-Basketball/allstars/allstars/templates/allstars/pagination.html' %} 
+  {% include 'allstars/pagination.html' %}
 
   {% if all_stars_list %}
   <ul>

--- a/allstars/allstars/templates/allstars/personlist.html
+++ b/allstars/allstars/templates/allstars/personlist.html
@@ -19,7 +19,7 @@
 
   <p> Select a person to get a profile with personal information, stats as a player (if applicable), and/or stats as a coach (if applicable). Stats as either a player or coach are listed below a person's personal information, and encompass play within a regular season.</p>
 
-  {% include '/Users/beefbeverly/Documents/GitHub/SI664-Final-Project-Mens-Basketball/allstars/allstars/templates/allstars/pagination.html' %} 
+  {% include 'allstars/pagination.html' %}
 
   {% if person_list %}
   <ul>

--- a/allstars/allstars/templates/allstars/teamlist.html
+++ b/allstars/allstars/templates/allstars/teamlist.html
@@ -17,7 +17,7 @@
 
         <p> Select a team below to see their profile. The profile contains a list of years the team was active, with wins, losses, and games played for each year recorded.</p>
 
-        {% include '/Users/beefbeverly/Documents/GitHub/SI664-Final-Project-Mens-Basketball/allstars/allstars/templates/allstars/pagination.html' %} 
+        {% include 'allstars/pagination.html' %}
 
         {% if team_list %}
         <ul>

--- a/allstars/api/views.py
+++ b/allstars/api/views.py
@@ -8,7 +8,7 @@ class PersonRecordViewSet(viewsets.ModelViewSet):
 	"""
 	This ViewSet provides both 'list' and 'detail' views.
 	"""
-	queryset = PersonRecord.objects.select_related('team_align', 'coach').order_by('last_name')
+	queryset = PersonRecord.objects.order_by('last_name')
 	serializer_class = PersonRecordSerializer
 	permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 


### PR DESCRIPTION
This PR fixes the following errors that otherwise would have prevented grading the final project:

* replaces use of absolute paths with relative paths in three templates (never use abs paths in web files).  In all three cases a runtime error was triggered.
* Fixes broken API `views.py` (bad QuerySet) and `serializers.py`. Multiple errors encountered when issuing GET, POST, and PUT requests.
* Cleans up `models.py`
* Updates `.gitignore` to exclude `venv/` and `secrets.py`.

### A sampling of API errors:

![image](https://user-images.githubusercontent.com/83268/50360436-05799780-052e-11e9-8354-0a3c845eee4f.png)
![image](https://user-images.githubusercontent.com/83268/50360450-0e6a6900-052e-11e9-94b8-065f4a7549d7.png)
![image](https://user-images.githubusercontent.com/83268/50360456-14604a00-052e-11e9-971e-b5b69ffe6281.png)


